### PR TITLE
Logger autoclosefds options

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -84,15 +84,17 @@ class Daemonize(object):
             devnull = os.devnull
 
         if self.auto_close_fds:
-            for fd in range(resource.getrlimit(resource.RLIMIT_NOFILE)[0]):
+            for fd in range(3, resource.getrlimit(resource.RLIMIT_NOFILE)[0]):
                 if fd not in self.keep_fds:
                     try:
                         os.close(fd)
                     except OSError:
                         pass
-            os.open(devnull, os.O_RDWR)
-            os.dup(0)
-            os.dup(0)
+
+        devnull_fd = os.open(devnull, os.O_RDWR)
+        os.dup2(devnull_fd, 0)
+        os.dup2(devnull_fd, 1)
+        os.dup2(devnull_fd, 2)
 
         if self.logger == None:
             # Initialize logging.


### PR DESCRIPTION
3bdb286 Ability to pass in own logger object if I have it already configured. Default value is None, in which case original logic of create logger, add syslog handler etc is run

a2cfbc5 Added auto_close_fds (default True) which can be set to False in case we don't want fds closed automatically. This was useful in one of our projects where the main program kept running and doing other things

1ef1325 Changed os.dup code to redirect 0,1,2 to dev null rather than closing and opening the fds. This is a bit more resilient/deterministic
