### PR TITLE
Python kill

### DIFF
--- a/tests/daemon_sigterm.py
+++ b/tests/daemon_sigterm.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
+from logging import basicConfig
 from sys import argv
 from time import sleep
 
 from daemonize import Daemonize
+
+basicConfig()
 
 pid = argv[1]
 


### PR DESCRIPTION
Use internal python os.kill rather than os.system and shell to kill child process in testing.
This includes the changes of the previous PR as commit 7f7a575.
