### PR TITLE
Make exiting in the parent optional both prior/post fork

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -254,9 +254,10 @@ class Daemonize(object):
             self.logger.error("Unable to write pid to the pidfile.")
             sys.exit(1)
 
+        # Ensure we clean up our pidfile
+        atexit.register(self.exit)
         # Set custom action on SIGTERM.
         signal.signal(signal.SIGTERM, self.sigterm)
-        atexit.register(self.exit)
 
         self.logger.info("Starting daemon.")
 

--- a/daemonize.py
+++ b/daemonize.py
@@ -13,7 +13,7 @@ import atexit
 from logging import handlers
 
 
-__version__ = "2.4.5"
+__version__ = "2.4.4"
 
 
 class Daemonize(object):

--- a/tests/daemon_chdir.py
+++ b/tests/daemon_chdir.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
+import logging
 from sys import argv
 
 from daemonize import Daemonize
+
+logging.basicConfig(level=logging.DEBUG)
 
 pid = argv[1]
 working_dir = argv[2]

--- a/tests/daemon_keep_fds.py
+++ b/tests/daemon_keep_fds.py
@@ -5,6 +5,8 @@ from sys import argv
 
 from daemonize import Daemonize
 
+logging.basicConfig(level=logging.DEBUG)
+
 pid = argv[1]
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)

--- a/tests/daemon_sigterm.py
+++ b/tests/daemon_sigterm.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
+from logging import basicConfig
 from sys import argv
 from time import sleep
 
 from daemonize import Daemonize
+
+basicConfig()
 
 pid = argv[1]
 

--- a/tests/daemon_sigterm.py
+++ b/tests/daemon_sigterm.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 
-from logging import basicConfig
+import logging
 from sys import argv
 from time import sleep
 
 from daemonize import Daemonize
 
-basicConfig()
+logging.basicConfig(level=logging.DEBUG)
 
 pid = argv[1]
 


### PR DESCRIPTION
Added two flags to Daemonize:
  raise_prior_to_fork - If True and an error is encountered prior
    to forking, raise rather than exiting
  return_in_parent - If True then return child's pid from start()
    after forking
Also shortened test sleeps to speed up iteration

This builds on the other to PRs