### PR TITLE
exceptions in the action kill the daemon but don't show up in the log

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -10,6 +10,7 @@ import resource
 import logging
 import atexit
 from logging import handlers
+import traceback
 
 
 __version__ = "2.4.3"
@@ -237,4 +238,8 @@ class Daemonize(object):
 
         self.logger.warn("Starting daemon.")
 
-        self.action(*privileged_action_result)
+        try:
+            self.action(*privileged_action_result)
+        except Exception as e:
+            for line in traceback.format_exc(e).split("\n"):
+                self.logger.error(line)


### PR DESCRIPTION
I first found this in daemonize 2.3.1 on Oracle Linux on Python 2.6.

If you pass daemonize an action that throws an exception, it will cause the daemonize thread to exit. The log will contain no messages other than "WARNING Stopping daemon", rather than the log message from a signal handler, so I'm not really sure what's going on re: how that exception is being passed up through daemonize's code.

What I DO know is that the exception (from the action) is not logged at all, and that makes troubleshooting daemons who fail in this way positively infuriating - in fact, it makes troubleshooting them basically impossible. To be fair, there's nothing that daemonize can reasonably *DO* with that exception; it's a daemon thread, so there's no choice but to exit when this happens. This pull ensures that, at the very least, the exception gets sent to the logger for the user to troubleshoot.