### PR TITLE
Add support for action_args and action_kwargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "3.4"
     - "3.5"
 install: sudo pip install nose sphinx sphinx_rtd_theme; sudo pip install .
-script: sudo nosetests && sudo make docs
+script: sudo nosetests -vv && sudo make docs
 notifications:
     webhooks:
         - http://tg.thesharp.org:8888/travis

--- a/daemonize.py
+++ b/daemonize.py
@@ -30,7 +30,9 @@ class Daemonize(object):
                               group parameter is provided.
                               If you want to transfer anything from privileged_action to action, such as
                               opened privileged file descriptor, you should return it from
-                              privileged_action function and catch it inside action function.
+                              privileged_action function. Whatever is returned
+                              from this function is passed to action as the
+                              first arg.
     :param user: drop privileges to this user if provided.
     :param group: drop privileges to this group if provided.
     :param verbose: send debug messages to logger if provided.

--- a/daemonize.py
+++ b/daemonize.py
@@ -1,5 +1,4 @@
-# #!/usr/bin/python
-
+#!/usr/bin/env python
 import fcntl
 import os
 import pwd

--- a/tests/daemon_action_args.py
+++ b/tests/daemon_action_args.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from sys import argv
+from time import sleep
+
+from daemonize import Daemonize
+
+pid = argv[1]
+log = argv[2]
+
+
+def main(a, b, c, language=None, debug=False):
+    with open(log, "w") as fp:
+        print(a, file=fp)
+        print(b, file=fp)
+        print(c, file=fp)
+        print(language, file=fp)
+        print(debug, file=fp)
+    while True:
+        sleep(5)
+
+daemon = Daemonize(app="test_app", pid=pid, action=main,
+                   action_args=("a", "b", "c"),
+                   action_kwargs={"language": "Python"})
+daemon.start()

--- a/tests/daemon_action_args_with_priviliged.py
+++ b/tests/daemon_action_args_with_priviliged.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+from __future__ import print_function
+from sys import argv
+from time import sleep
+
+from daemonize import Daemonize
+
+pid = argv[1]
+log = argv[2]
+
+
+def privileged_action():
+    return ("x", "y", "z")
+
+
+def main(x, y, z, a, b, c, language=None, debug=False):
+    with open(log, "w") as fp:
+        print(x, file=fp)
+        print(y, file=fp)
+        print(z, file=fp)
+        print(a, file=fp)
+        print(b, file=fp)
+        print(c, file=fp)
+        print(language, file=fp)
+        print(debug, file=fp)
+    while True:
+        sleep(5)
+
+daemon = Daemonize(app="test_app", pid=pid, action=main,
+                   action_args=("a", "b", "c"),
+                   action_kwargs={"language": "Python"},
+                   privileged_action=privileged_action)
+daemon.start()

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,6 +2,7 @@ import grp
 import os
 import pwd
 import subprocess
+import textwrap
 import unittest
 
 from tempfile import mkstemp
@@ -113,11 +114,12 @@ class UidGidTest(unittest.TestCase):
 
 class PrivilegedActionTest(unittest.TestCase):
     def setUp(self):
-        self.correct_log = """Privileged action.
-Starting daemon.
-Action.
-Stopping daemon.
-"""
+        self.correct_log = textwrap.dedent("""
+        Privileged action.
+        Starting daemon.
+        Action.
+        Stopping daemon.
+        """).lstrip()
         self.pidfile = mkstemp()[1]
         self.logfile = mkstemp()[1]
         os.system("python tests/daemon_privileged_action.py %s %s" % (self.pidfile, self.logfile))

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import grp
 import os
 import pwd

--- a/tests/test.py
+++ b/tests/test.py
@@ -153,5 +153,60 @@ class ChdirTest(unittest.TestCase):
         log = open(self.target, "r").read()
         self.assertEqual(log, "test")
 
+
+class ArgsKwargsActionTest(unittest.TestCase):
+    def setUp(self):
+        self.pidfile = mkstemp()[1]
+        self.logfile = mkstemp()[1]
+        self.expected_logfile = textwrap.dedent("""
+        a
+        b
+        c
+        Python
+        False
+        """).lstrip()
+        os.system("python tests/daemon_action_args.py %s %s" % (self.pidfile, self.logfile))
+        sleep(10)
+
+    def tearDown(self):
+        os.system("kill `cat %s`" % self.pidfile)
+        os.remove(self.logfile)
+        sleep(.1)
+
+    def test_is_working(self):
+        with open(self.logfile) as logfile:
+            actual = logfile.read()
+            self.assertEqual(actual, self.expected_logfile)
+
+
+class ArgsKwargsWithPriviledgedTest(unittest.TestCase):
+    def setUp(self):
+        self.pidfile = mkstemp()[1]
+        self.logfile = mkstemp()[1]
+        self.expected_logfile = textwrap.dedent("""
+        x
+        y
+        z
+        a
+        b
+        c
+        Python
+        False
+        """).lstrip()
+        os.system("python tests/daemon_action_args_with_priviliged.py %s %s" % (self.pidfile, self.logfile))
+        sleep(10)
+
+
+    def tearDown(self):
+        os.system("kill `cat %s`" % self.pidfile)
+        os.remove(self.logfile)
+        sleep(.1)
+
+    def test_is_working(self):
+        with open(self.logfile) as logfile:
+            actual = logfile.read()
+            self.assertEqual(actual, self.expected_logfile)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,8 +1,8 @@
-import unittest
+import grp
 import os
 import pwd
-import grp
 import subprocess
+import unittest
 
 from tempfile import mkstemp
 from time import sleep


### PR DESCRIPTION
This PR allows users to pass optional args and kwargs to their `action` function. It combines args that may have been received from `privileged_action()` and updates the documentation to clarify that.

Also makes a few very minor improvements.