### PR TITLE
Fixed exception handling

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -243,6 +243,6 @@ class Daemonize(object):
 
         try:
             self.action(*privileged_action_result)
-        except Exception as e:
-            for line in traceback.format_exc(e).split("\n"):
+        except Exception:
+            for line in traceback.format_exc().split("\n"):
                 self.logger.error(line)


### PR DESCRIPTION
traceback.format_exc() doesn't take an exception object as argument. This leads to subsequent exceptions inside the format_exc function that hide the original error.