### PR TITLE
Don't call `sys.exit` in `atexit` callback

### DIFF
--- a/daemonize.py
+++ b/daemonize.py
@@ -69,7 +69,6 @@ class Daemonize(object):
         """
         self.logger.warn("Stopping daemon.")
         os.remove(self.pid)
-        sys.exit(0)
 
     def start(self):
         """


### PR DESCRIPTION
Python is already shutting down. Calling `exit` again is an error.